### PR TITLE
[haxcms-php] Fix HAXiam 403 on site lifecycle mutations

### DIFF
--- a/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
+++ b/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
@@ -194,14 +194,22 @@ class SystemApiSecurity
         // hand-maintained public/authenticated route lists.
         $basePolicy = SiteRouteUtils::getSystemApiRouteAuthPolicy($route, $normalizedMethod);
         // PHP admin tier (Q1: no Node equivalent): elevate non-GET methods of
-        // admin routes to 'admin' so the superUser check fires. GET stays at
-        // the spec-driven base policy (authenticated/authenticated-user) since
-        // the spec declares bearerAuth for dashboard reads. The admin route
-        // list is the single source of truth for which routes require admin.
+        // true system-admin-dashboard routes to 'admin' so the superUser check
+        // fires. GET stays at the spec-driven base policy
+        // (authenticated/authenticated-user) since the spec declares bearerAuth
+        // for dashboard reads. The superUser-elevation set is
+        // getSystemV1SuperUserRoutes() (skeleton/theme/block management, status,
+        // configuration, schemas, entities) — NOT the full referer-gate list in
+        // getSystemV1AdminRoutes(), which also covers site-lifecycle routes
+        // (sites, clone, archive, download, download-skeleton, save-as-template)
+        // that any authenticated user must be able to mutate. Elevating those
+        // would 403 the HAXiam tenant principal (never the superUser) on every
+        // site-lifecycle POST; leaving them out lets them fall through to the
+        // spec-driven authenticated policy, matching Node behavior.
         if (
             $normalizedMethod !== 'GET' &&
             $normalizedMethod !== 'HEAD' &&
-            in_array($route, SystemRoutesMap::getSystemV1AdminRoutes(), true)
+            in_array($route, SystemRoutesMap::getSystemV1SuperUserRoutes(), true)
         ) {
             return 'admin';
         }

--- a/system/backend/php/lib/systemRoutes/SystemRoutesMap.php
+++ b/system/backend/php/lib/systemRoutes/SystemRoutesMap.php
@@ -42,6 +42,42 @@ class SystemRoutesMap
             'v1/themes',
         );
     }
+    /**
+     * Subset of getSystemV1AdminRoutes() whose NON-GET methods require the
+     * superUser principal (the true system-admin-dashboard routes: skeleton,
+     * theme, block management, status, configuration, schemas, entities).
+     * SystemApiSecurity::getRouteSecurity() elevates non-GET/HEAD methods of
+     * these routes to the 'admin' security level so the superUser check fires.
+     *
+     * Site-lifecycle routes (sites, sites/:siteName/clone, /archive, /download,
+     * /download-skeleton, /save-as-template) are intentionally NOT listed here:
+     * any authenticated user (including the HAXiam tenant principal) must be
+     * able to run their mutations, so their non-GET methods fall through to the
+     * spec-driven base policy (bearerAuth + userTokenHeader -> authenticated).
+     *
+     * getSystemV1AdminRoutes() remains the full set used by
+     * validateSystemV1RouteAccess() for the site-scoped-referer gate; that gate
+     * is correct for the full set and is a separate concern from superUser
+     * elevation. Node has no equivalent elevation (the Q1 comment in
+     * SystemApiSecurity.php); this split aligns PHP with Node for site-lifecycle
+     * mutations while keeping dashboard-management routes superUser-gated.
+     */
+    public static function getSystemV1SuperUserRoutes()
+    {
+        return array(
+            'v1/status',
+            'v1/system/version',
+            'v1/entities',
+            'v1/schemas',
+            'v1/configuration/api-keys',
+            'v1/configuration/media',
+            'v1/configuration/schema-files/operations',
+            'v1/blocks',
+            'v1/skeletons',
+            'v1/skeletons/:skeletonName',
+            'v1/themes',
+        );
+    }
     public static function getRoutesMap()
     {
         return array(

--- a/system/backend/php/tests/v1-integration-tests.php
+++ b/system/backend/php/tests/v1-integration-tests.php
@@ -317,6 +317,15 @@ assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/status', 'GET'
 assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/configuration/api-keys', 'GET'), 'v1/configuration/api-keys GET is authenticated');
 assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/blocks', 'GET'), 'v1/blocks GET is authenticated');
 assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites', 'GET'), 'v1/sites is authenticated');
+// Site-lifecycle mutations must NOT elevate to 'admin' — they fall through to
+// the spec-driven authenticated policy so the HAXiam tenant principal (never
+// the superUser) can create/clone/archive/download/save-as-template. The
+// superUser-elevation set (getSystemV1SuperUserRoutes) excludes these routes.
+assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites', 'POST'), 'v1/sites POST is authenticated');
+assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites/:siteName/clone', 'POST'), 'v1/sites/:siteName/clone POST is authenticated');
+assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites/:siteName/archive', 'POST'), 'v1/sites/:siteName/archive POST is authenticated');
+assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites/:siteName/download-skeleton', 'POST'), 'v1/sites/:siteName/download-skeleton POST is authenticated');
+assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/sites/:siteName/save-as-template', 'POST'), 'v1/sites/:siteName/save-as-template POST is authenticated');
 assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/themes', 'GET'), 'v1/themes GET is authenticated');
 assertEquals('admin', $getRouteSecurity->invoke(null, 'v1/themes', 'POST'), 'v1/themes POST is admin');
 assertEquals('authenticated', $getRouteSecurity->invoke(null, 'v1/skeletons', 'GET'), 'v1/skeletons GET is authenticated');


### PR DESCRIPTION
## Problem
On HAXiam (PHP core, `config->iam = true`), every site-lifecycle **mutation** returns 403 while reads succeed:
- Works: `GET /system/api/v1/sites`, `GET .../session/connection-test`, `GET .../session/user`.
- 403s: `POST .../sites` (createSite), `POST .../sites/{name}/clone`, `/archive`, `/download`, `/download-skeleton`, `/save-as-template`.
- `POST .../actions/import-docx` returns 200 and processes the file, but the frontend's subsequent `createSite` handoff 403s.

This happens only on HAXiam + haxcms-php. Standalone haxcms-php and haxcms-nodejs are unaffected.

## Root cause
`SystemApiSecurity::getRouteSecurity()` elevates **non-GET** methods of every route in `SystemRoutesMap::getSystemV1AdminRoutes()` to the `'admin'` security level. That list conflated two concepts:
1. True system-admin-dashboard routes (skeleton/theme/block management, status, configuration, schemas, entities).
2. Site-lifecycle routes any authenticated user must run (`sites`, `clone`, `archive`, `download`, `download-skeleton`, `save-as-template`).

The `admin` branch of `validateSystemApiAccess()` requires `userName === HAXCMS->superUser->name`. In HAXiam the authenticated principal is the IAM tenant user (e.g. `bto108`), never the superUser, so every non-GET site-lifecycle route 403s with `\"Admin access required\"`. Node has no such elevation (the code comment at `SystemApiSecurity.php:196` says \"PHP admin tier (Q1: no Node equivalent)\").

## Fix
Split the list:
- `getSystemV1AdminRoutes()` — **unchanged**, still used by `validateSystemV1RouteAccess()` for the site-scoped-referer gate.
- New `getSystemV1SuperUserRoutes()` — only the true system-admin-dashboard routes (status, version, entities, schemas, configuration/api-keys, configuration/media, configuration/schema-files/operations, blocks, skeletons, skeletons/:skeletonName, themes).
- `getRouteSecurity()` now uses `getSystemV1SuperUserRoutes()` for the non-GET admin-elevation `in_array`.

After this, site-lifecycle non-GET routes fall through to the spec-driven base policy (`bearerAuth + userTokenHeader` → `authenticated-user` → `authenticated`), pass `validateIAMRouteAuthorization(true)` for the matching tenant, and return 200. True admin-dashboard routes stay `admin`/superUser-gated. Standalone PHP is unaffected (superUser still passes `authenticated`).

## Validation
- \`php -l\` on all three edited files: no syntax errors.
- \`php system/backend/php/tests/v1-integration-tests.php\` → Passed: 121, Failed: 0.
- \`php system/backend/php/tests/systemRoutes/SystemRoutesTest.php\` → Passed: 75, Failed: 0.
- New assertions lock `v1/sites` POST, `v1/sites/:siteName/clone|archive|download-skeleton|save-as-template` POST as `authenticated`. Existing assertions for `v1/themes` POST, `v1/skeletons` POST, `v1/configuration/api-keys` GET, `v1/blocks` GET staying `admin` remain unchanged and pass.

## Files
- `system/backend/php/lib/systemRoutes/SystemRoutesMap.php` — add `getSystemV1SuperUserRoutes()`.
- `system/backend/php/lib/systemRoutes/SystemApiSecurity.php` — use it for non-GET elevation; updated comment.
- `system/backend/php/tests/v1-integration-tests.php` — 5 new assertions.

Companion frontend PR: haxtheweb/webcomponents#PR (app-hax 403 error reporting).

Co-Authored-By: Oz <oz-agent@warp.dev>