### PR TITLE
[haxcms-php] Stepped installer wizard, secure hosting-provider token bypass, localization settings

### DIFF
--- a/Dockerfile.precondition-test
+++ b/Dockerfile.precondition-test
@@ -1,0 +1,35 @@
+# Minimal HAXcms precondition-test image.
+#
+# Intentionally omits git, the PHP curl extension, and ships a read-only
+# webroot so that the installer wizard's Step 1 status report surfaces the
+# expected warnings/errors for each missing precondition. This is the test
+# housing requested in haxtheweb/issues#2974: a container that deliberately
+# does NOT satisfy preconditions so the installer's gating UI is exercised.
+#
+# Build:  docker build -f Dockerfile.precondition-test -t haxcms-precondition-test .
+# Run:    docker run --rm -p 8080:80 haxcms-precondition-test
+# Then visit http://localhost:8080/install.php and verify the status report
+# shows: PHP curl extension = Missing (error), Git availability = Not
+# detected (warning), and the webroot directory = Read-only (error).
+#
+# The full-featured image is Dockerfile (php:8.3-apache + git + gd + curl).
+
+FROM php:8.3-apache
+
+# Enable Apache rewrite (required for HAXcms routing) but do NOT install
+# git, libcurl4-openssl-dev, or the php curl extension — those omissions are
+# the point of this image.
+RUN a2enmod rewrite
+
+# Custom apache conf (same as the full image so routing behaves identically).
+COPY ./scripts/docker/apache2.conf /etc/apache2/apache2.conf
+
+# Copy HAXcms into the web root. We intentionally do NOT chown to www-data
+# and instead make the tree read-only so the installer's directory
+# writability checks report errors (the precondition we want to surface).
+COPY . /var/www/html
+RUN chmod -R 555 /var/www/html && \
+    chown -R root:root /var/www/html
+
+# Expose Apache.
+EXPOSE 80

--- a/install.php
+++ b/install.php
@@ -1,28 +1,65 @@
 <?php
+// HAXcms installer — stepped wizard with precondition checks, secure
+// hosting-provider credential override, and default-language selection.
+// See haxtheweb/issues#2974 for the design rationale.
+//
+// Flow:
+//   Step 1 (status)   — precondition / environment check report
+//   Step 2 (confirm)  — confirm admin username + select default language
+//   Step 3 (install)  — run setup, then render success screen with credentials
+//
+// Hosting-provider automation (e.g. Reclaim Cloud / haxcms-jps) may POST
+// user + pass + install_token directly to skip the interactive wizard. The
+// credential override is honored ONLY when a pre-dropped _installtoken.txt
+// file matches the POSTed install_token (timing-safe hash_equals). Without
+// the token file, POST-supplied credentials are ignored and the installer
+// uses an auto-generated admin password — closing the unauthenticated
+// credential-race for the default/common case.
+
 $failed = false;
+$failedMessages = array();
+$resolvedUsername = 'admin';
+$pass = '';
+$passwordWasGenerated = false;
+
 include_once __DIR__ . '/system/backend/php/lib/SystemStatusService.php';
+include_once __DIR__ . '/system/backend/php/lib/LocalizationSettingsService.php';
+include_once __DIR__ . '/system/backend/php/lib/Git.php';
+
 // Security best practice (I5): once HAXcms is already installed (the four
 // core directories exist), the installer must never run setup logic again —
 // it is an unauthenticated endpoint that creates credentials and secrets.
 // Redirect to the dashboard and stop before any POST/file logic executes.
-// This makes the existing post-install redirect authoritative and early.
-if (is_dir(__DIR__ . '/_sites') && is_dir(__DIR__ . '/_config') && is_dir(__DIR__ . '/_published') && is_dir(__DIR__ . '/_archived')) {
+if (
+  is_dir(__DIR__ . '/_sites') &&
+  is_dir(__DIR__ . '/_config') &&
+  is_dir(__DIR__ . '/_published') &&
+  is_dir(__DIR__ . '/_archived')
+) {
   header('Location: index.php');
   exit();
 }
 
+// --- version ---------------------------------------------------------------
+$version = '';
+$versionFiles = array(
+  __DIR__ . '/.version',
+  __DIR__ . '/VERSION.txt',
+);
+foreach ($versionFiles as $versionFile) {
+  if (file_exists($versionFile)) {
+    $version = filter_var(file_get_contents($versionFile));
+    break;
+  }
+}
+
+// --- helpers ---------------------------------------------------------------
 if (!function_exists('haxcmsInstallerStatusToneClass')) {
   function haxcmsInstallerStatusToneClass($tone)
   {
-    if ($tone === 'ok') {
-      return 'status-tone-ok';
-    }
-    if ($tone === 'warning') {
-      return 'status-tone-warning';
-    }
-    if ($tone === 'error') {
-      return 'status-tone-error';
-    }
+    if ($tone === 'ok') { return 'status-tone-ok'; }
+    if ($tone === 'warning') { return 'status-tone-warning'; }
+    if ($tone === 'error') { return 'status-tone-error'; }
     return 'status-tone-info';
   }
 }
@@ -49,16 +86,14 @@ if (!function_exists('haxcmsInstallerStatusRender')) {
     print '<h2>System status checks</h2>';
     print '<p class="status-summary">';
     print 'Runtime: ' . haxcmsInstallerStatusEscape($runtime);
-    print ' · Server: ' . haxcmsInstallerStatusEscape($server);
-    print ' · HAXcms: ' . haxcmsInstallerStatusEscape($currentVersion);
+    print ' &middot; Server: ' . haxcmsInstallerStatusEscape($server);
+    print ' &middot; HAXcms: ' . haxcmsInstallerStatusEscape($currentVersion);
     print ' (latest: ' . haxcmsInstallerStatusEscape($latestVersion) . ')';
     print '</p>';
     print '<table class="status-table" aria-label="Installer system status checks">';
     print '<thead><tr><th>Check</th><th>Status</th><th>Details</th></tr></thead><tbody>';
     foreach ($statusReport['rows'] as $row) {
-      if (!is_array($row)) {
-        continue;
-      }
+      if (!is_array($row)) { continue; }
       $tone = isset($row['tone']) ? $row['tone'] : 'info';
       $title = isset($row['title']) ? $row['title'] : '';
       $value = isset($row['value']) ? $row['value'] : '';
@@ -72,39 +107,299 @@ if (!function_exists('haxcmsInstallerStatusRender')) {
     print '</tbody></table></div>';
   }
 }
-$version = '';
-$versionFiles = array(
-  __DIR__ . '/.version',
-  __DIR__ . '/VERSION.txt',
-);
-foreach ($versionFiles as $versionFile) {
-  if (file_exists($versionFile)) {
-    $version = filter_var(file_get_contents($versionFile));
-    break;
+if (!function_exists('haxcmsInstallerPasswordMeetsPolicy')) {
+  function haxcmsInstallerPasswordMeetsPolicy($password)
+  {
+    if (!is_string($password) || strlen($password) < 10) {
+      return false;
+    }
+    if (!preg_match('/[a-zA-Z]/', $password) || !preg_match('/[0-9]/', $password)) {
+      return false;
+    }
+    return true;
   }
 }
-// check for core directories existing, redirect if we do
-if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_archived')) {
-  header("Location: index.php");
-  exit();
-} else { ?>
+if (!function_exists('haxcmsInstallerGeneratePassword')) {
+  function haxcmsInstallerGeneratePassword()
+  {
+    $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789';
+    $pass = array();
+    $alphaLength = strlen($alphabet) - 1;
+    for ($i = 0; $i < 14; $i++) {
+      $n = random_int(0, $alphaLength);
+      $pass[] = $alphabet[$n];
+    }
+    return implode($pass);
+  }
+}
+if (!function_exists('haxcmsInstallerGuardedMkdir')) {
+  function haxcmsInstallerGuardedMkdir($path, $permissions, &$failed, &$failedMessages)
+  {
+    if (!is_dir($path)) {
+      if (!@mkdir($path, $permissions)) {
+        $failed = true;
+        $failedMessages[] = 'Unable to create directory: ' . $path;
+        return false;
+      }
+    }
+    return true;
+  }
+}
+if (!function_exists('haxcmsInstallerGuardedGitCreate')) {
+  function haxcmsInstallerGuardedGitCreate($path, &$failed, &$failedMessages)
+  {
+    try {
+      $git = new Git();
+      $git->create($path);
+      return true;
+    } catch (Exception $e) {
+      $failed = true;
+      $failedMessages[] = 'Unable to initialize git repository in ' . $path . ': ' . $e->getMessage();
+      return false;
+    }
+  }
+}
+
+// --- install token gating --------------------------------------------------
+// Hosting providers (e.g. Reclaim Cloud via haxcms-jps) may pre-drop a
+// _installtoken.txt file containing a random secret, then POST user/pass/
+// install_token to automate the install. When the token file is present,
+// POST-supplied credentials are honored ONLY if install_token matches
+// (timing-safe hash_equals). When the token file is absent, POST-supplied
+// credentials are ignored entirely and the installer always uses the
+// auto-generated admin/password path.
+$installTokenFilePath = __DIR__ . '/_installtoken.txt';
+$installTokenFromFile = '';
+if (file_exists($installTokenFilePath) && is_file($installTokenFilePath)) {
+  $installTokenFromFile = trim(file_get_contents($installTokenFilePath));
+}
+$installTokenEnabled = ($installTokenFromFile !== '');
+
+// --- step detection --------------------------------------------------------
+$step = 'status';
+$isDirectInstall = false;
+// Hosting-provider automation sends user/pass directly (no interactive wizard)
+if (isset($_POST['user']) || isset($_POST['pass'])) {
+  $isDirectInstall = true;
+  $step = 'install';
+} else if (isset($_POST['step'])) {
+  $step = filter_var($_POST['step'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+}
+
+// --- selected language -----------------------------------------------------
+$selectedLanguage = 'en-US';
+if (isset($_POST['language']) && is_string($_POST['language'])) {
+  $normalized = HAXCMSLocalizationSettingsService::normalizeDefaultLanguageValue($_POST['language']);
+  if ($normalized !== null) {
+    $selectedLanguage = $normalized;
+  }
+}
+
+// --- token validation for direct install -----------------------------------
+$directInstallTokenError = '';
+if ($isDirectInstall) {
+  if ($installTokenEnabled) {
+    $postedToken = isset($_POST['install_token']) ? (string) $_POST['install_token'] : '';
+    if ($postedToken === '' || !hash_equals($installTokenFromFile, $postedToken)) {
+      $directInstallTokenError = 'Invalid or missing install token. POST-supplied credentials were not applied.';
+      $isDirectInstall = false;
+      $step = 'status';
+    }
+  } else {
+    // No token file — ignore POSTed credentials entirely (race-closed)
+    $isDirectInstall = false;
+    $step = 'status';
+  }
+}
+
+// --- install execution (step=install) --------------------------------------
+$installerStatusReport = HAXCMSSystemStatusService::buildInstallerStatusReport(__DIR__);
+$configExisted = is_dir(__DIR__ . '/_config');
+
+if ($step === 'install' && !$failed) {
+  $generateSecureSecret = function () {
+    $parts = array();
+    for ($i = 0; $i < 4; $i++) {
+      $parts[] = bin2hex(random_bytes(16));
+    }
+    return implode('-', $parts);
+  };
+
+  // resolve username (POSTed from wizard form, or from hosting-provider POST)
+  if ($isDirectInstall && isset($_POST['user']) && is_string($_POST['user']) && trim($_POST['user']) !== '') {
+    $resolvedUsername = filter_var($_POST['user'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+  } else if (isset($_POST['username']) && is_string($_POST['username']) && trim($_POST['username']) !== '') {
+    $resolvedUsername = filter_var($_POST['username'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+  } else {
+    $resolvedUsername = 'admin';
+  }
+
+  // resolve password
+  if ($isDirectInstall && isset($_POST['pass']) && is_string($_POST['pass']) && $_POST['pass'] !== '') {
+    $pass = $_POST['pass'];
+    if (!haxcmsInstallerPasswordMeetsPolicy($pass)) {
+      $failed = true;
+      $failedMessages[] = 'POST-supplied password does not meet the minimum policy (10+ chars, at least one letter and one number).';
+    }
+  } else {
+    $pass = haxcmsInstallerGeneratePassword();
+    $passwordWasGenerated = true;
+  }
+
+  if (!$failed) {
+    // --- _config directory + boilerplate ---
+    if (!is_dir(__DIR__ . '/_config')) {
+      if (haxcmsInstallerGuardedMkdir(__DIR__ . '/_config', 0755, $failed, $failedMessages)) {
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/.ssh', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/tmp', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/cache', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/settings', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/user', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/user/files', 0755, $failed, $failedMessages);
+        haxcmsInstallerGuardedMkdir(__DIR__ . '/_config/node_modules', 0755, $failed, $failedMessages);
+
+        // boilerplate files
+        copy(__DIR__ . '/system/boilerplate/systemsetup/config.json', __DIR__ . '/_config/config.json');
+        copy(__DIR__ . '/system/boilerplate/systemsetup/my-custom-elements.js', __DIR__ . '/_config/my-custom-elements.js');
+        copy(__DIR__ . '/system/boilerplate/systemsetup/userData.json', __DIR__ . '/_config/userData.json');
+        copy(__DIR__ . '/system/boilerplate/systemsetup/config.php', __DIR__ . '/_config/config.php');
+        copy(__DIR__ . '/system/boilerplate/systemsetup/.htaccess', __DIR__ . '/_config/.htaccess');
+        copy(__DIR__ . '/system/boilerplate/systemsetup/.user-files-htaccess', __DIR__ . '/_config/user/files/.htaccess');
+
+        // set the default language in config.json localization block
+        $configJsonPath = __DIR__ . '/_config/config.json';
+        $configJsonRaw = @file_get_contents($configJsonPath);
+        $configJson = json_decode($configJsonRaw, true);
+        if (is_array($configJson)) {
+          if (!isset($configJson['localization']) || !is_array($configJson['localization'])) {
+            $configJson['localization'] = array();
+          }
+          $configJson['localization']['defaultLanguage'] = $selectedLanguage;
+          file_put_contents($configJsonPath, json_encode($configJson, JSON_PRETTY_PRINT) . PHP_EOL, LOCK_EX);
+        }
+
+        // permissions
+        chmod(__DIR__ . '/_config', 0755);
+        chmod(__DIR__ . '/_config/tmp', 0755);
+        chmod(__DIR__ . '/_config/config.json', 0644);
+        chmod(__DIR__ . '/_config/userData.json', 0644);
+
+        // marker file
+        file_put_contents(__DIR__ . '/_config/.isHAXcmsConfig', '');
+
+        // SALT — restrict to 0600, write with LOCK_EX (SEC-10)
+        file_put_contents(__DIR__ . '/_config/SALT.txt', $generateSecureSecret(), LOCK_EX);
+        @chmod(__DIR__ . '/_config/SALT.txt', 0600);
+
+        // config.php templating
+        $configFile = file_get_contents(__DIR__ . '/_config/config.php');
+        $configFile = str_replace('HAXTHEWEBPRIVATEKEY', $generateSecureSecret(), $configFile);
+        $configFile = str_replace('HAXTHEWEBREFRESHPRIVATEKEY', $generateSecureSecret(), $configFile);
+        $configFile = str_replace('jeff', $resolvedUsername, $configFile);
+        // persist a password_hash (bcrypt/argon2), never the plaintext
+        $configFile = str_replace('jimmerson', password_hash($pass, PASSWORD_DEFAULT), $configFile);
+        // basePath locked to where this was installed
+        $basePath = str_replace('install.php', '', $_SERVER['SCRIPT_NAME']);
+        $configFile = str_replace("->basePath = '/'", "->basePath = '$basePath'", $configFile);
+        // config.php holds JWT private key + password hash; restrict to 0600 (SEC-10)
+        file_put_contents(__DIR__ . '/_config/config.php', $configFile, LOCK_EX);
+        @chmod(__DIR__ . '/_config/config.php', 0600);
+
+        // git init for _config
+        haxcmsInstallerGuardedGitCreate(__DIR__ . '/_config', $failed, $failedMessages);
+      }
+    }
+
+    // --- _sites directory ---
+    if (!is_dir(__DIR__ . '/_sites')) {
+      if (haxcmsInstallerGuardedMkdir(__DIR__ . '/_sites', 0755, $failed, $failedMessages)) {
+        chmod(__DIR__ . '/_sites', 0755);
+        @chown(__DIR__ . '/_sites', get_current_user());
+        @chgrp(__DIR__ . '/_sites', get_current_user());
+        haxcmsInstallerGuardedGitCreate(__DIR__ . '/_sites', $failed, $failedMessages);
+      }
+    }
+
+    // --- _published directory ---
+    if (!is_dir(__DIR__ . '/_published')) {
+      if (haxcmsInstallerGuardedMkdir(__DIR__ . '/_published', 0755, $failed, $failedMessages)) {
+        chmod(__DIR__ . '/_published', 0755);
+        @chown(__DIR__ . '/_published', get_current_user());
+        @chgrp(__DIR__ . '/_published', get_current_user());
+      }
+    }
+
+    // --- _archived directory ---
+    if (!is_dir(__DIR__ . '/_archived')) {
+      if (haxcmsInstallerGuardedMkdir(__DIR__ . '/_archived', 0755, $failed, $failedMessages)) {
+        chmod(__DIR__ . '/_archived', 0755);
+        @chown(__DIR__ . '/_archived', get_current_user());
+        @chgrp(__DIR__ . '/_archived', get_current_user());
+      }
+    }
+
+    // --- delete install token file (one-time use) ---
+    if (!$failed && $installTokenEnabled && file_exists($installTokenFilePath)) {
+      @unlink($installTokenFilePath);
+    }
+  }
+
+  // rebuild status report after install attempt
+  $installerStatusReport = HAXCMSSystemStatusService::buildInstallerStatusReport(__DIR__);
+}
+
+// determine whether any status rows are errors (for step 1 gating display)
+$statusHasErrors = false;
+if (is_array($installerStatusReport) && isset($installerStatusReport['rows'])) {
+  foreach ($installerStatusReport['rows'] as $row) {
+    if (is_array($row) && isset($row['tone']) && $row['tone'] === 'error') {
+      $statusHasErrors = true;
+      break;
+    }
+  }
+}
+?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<?php print haxcmsInstallerStatusEscape($selectedLanguage); ?>">
   <head>
     <meta charset="utf-8">
     <title>HAXcms Installation</title>
     <link rel="preload" href="./build/es6/dist/build-install.js" as="script" crossorigin="anonymous">
     <link rel="preload" href="./build/es6/node_modules/@haxtheweb/app-hax/app-hax.js"
       as="script" crossorigin="anonymous">
-    <link rel="preconnect" crossorigin href="https://fonts.googleapis.com">
-    <link rel="preconnect" crossorigin href="https://cdnjs.cloudflare.com">   
     <style>
+      /* DDD-aware installer styling with dark-mode support */
+      :root {
+        --installer-bg: #ffffff;
+        --installer-surface: #f6f6f6;
+        --installer-text: #1a1a1a;
+        --installer-border: #d8d8d8;
+        --installer-accent: var(--ddd-primary-1, #1a73e8);
+        --installer-accent-hover: var(--ddd-primary-2, #1557b0);
+        --installer-success: #2e7d32;
+        --installer-warning: #f9a825;
+        --installer-error: #c62828;
+        --installer-info: #1565c0;
+        --installer-code-bg: #333333;
+        --installer-code-text: #ffd700;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --installer-bg: #121212;
+          --installer-surface: #1e1e1e;
+          --installer-text: #e0e0e0;
+          --installer-border: #333333;
+          --installer-code-bg: #1a1a1a;
+        }
+      }
       body {
         margin: 0;
         padding: 0;
         overflow-x: hidden;
-        --app-hax-accent-color: black;
-        --app-hax-background-color: white;
+        background-color: var(--installer-bg);
+        color: var(--installer-text);
+        --app-hax-accent-color: var(--installer-text);
+        --app-hax-background-color: var(--installer-bg);
         --simple-tooltip-background: #000000;
         --simple-tooltip-opacity: 1;
         --simple-tooltip-text-color: #ffffff;
@@ -115,47 +410,27 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
         --simple-tooltip-font-size: 14px;
       }
       pre {
-        background-color: #333333;
-        color: yellow;
+        background-color: var(--installer-code-bg);
+        color: var(--installer-code-text);
         padding: 8px;
+        border-radius: 4px;
+        overflow-x: auto;
       }
       .version {
         position: fixed;
         left: 0;
         bottom: 0;
-        background-color:  yellow;
+        background-color: var(--installer-accent);
         display: inline-block;
         padding: 8px;
-        color: black;
-        border-right: 3px solid black;
-        border-top: 3px solid black;
+        color: #ffffff;
+        border-right: 3px solid var(--installer-text);
+        border-top: 3px solid var(--installer-text);
+        font-weight: bold;
+        font-size: 14px;
       }
-      button.hax-btn {
-        font-size: 40px;
-        transition: .2s all ease-in-out;
-        padding: 8px;
-        margin: 4px;
-        color: white;
-        background-color: darkblue;
-        border: 4px solid black;
-        border-radius: 8px;
-      }
-      button.hax-btn.smaller {
-        font-size: 20px;
-      }
-      button.hax-btn:focus,
-      button.hax-btn:hover {
-        cursor: pointer;
-        background-color: green;
-      }
-
-      button.hax-btn:active {
-        background-color: blue;
-        border: 6px solid blue;
-      }
-
-      p,ul,li {
-        font-size: 24px;
+      p, ul, li {
+        font-size: 18px;
       }
       hax-logo {
         --hax-logo-letter-spacing: 1px;
@@ -164,23 +439,16 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
         margin: 16px 0 50px;
       }
       @media screen and (max-width: 600px) {
-        hax-logo {
-          --hax-logo-font-size: 20px;
-        }
+        hax-logo { --hax-logo-font-size: 20px; }
       }
-      .version {
-        float:right;
-        font-weight: bold;
-      }
-      ul li {
-        padding: 4px;
-      }
+      ul li { padding: 4px; }
       ul li strong {
         padding: 8px;
-        font-size: 40px;
+        font-size: 24px;
         line-height: 1.5;
-        background-color: rgba(12,12,12,.05);
+        background-color: var(--installer-surface);
         margin-left: 16px;
+        border-radius: 4px;
       }
       .wrapper {
         padding: 16px;
@@ -190,7 +458,8 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
       }
       .card {
         width: 60vw;
-        background-color: white;
+        max-width: 800px;
+        background-color: var(--installer-bg);
         padding: 0 16px;
       }
       git-corner {
@@ -198,31 +467,147 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
         top: 0;
         position: fixed;
       }
-      button {
-        text-transform: none;
-      }
       h1 {
         margin: 16px;
         padding: 0;
         font-size: 30px;
         text-align: center;
-
       }
+      .step-indicator {
+        display: flex;
+        justify-content: center;
+        gap: 8px;
+        margin: 16px 0 32px;
+      }
+      .step-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background-color: var(--installer-border);
+      }
+      .step-dot.active { background-color: var(--installer-accent); }
+      .step-dot.done { background-color: var(--installer-success); }
+      .install-form {
+        max-width: 480px;
+        margin: 0 auto;
+      }
+      .install-form label {
+        display: block;
+        font-size: 16px;
+        font-weight: 600;
+        margin: 16px 0 4px;
+      }
+      .install-form input,
+      .install-form select {
+        width: 100%;
+        padding: 8px 12px;
+        font-size: 16px;
+        border: 2px solid var(--installer-border);
+        border-radius: 4px;
+        background-color: var(--installer-bg);
+        color: var(--installer-text);
+        box-sizing: border-box;
+      }
+      .install-form input:focus,
+      .install-form select:focus {
+        border-color: var(--installer-accent);
+        outline: none;
+      }
+      .install-form .help-text {
+        font-size: 14px;
+        opacity: 0.7;
+        margin: 4px 0 0;
+      }
+      .btn-row {
+        display: flex;
+        justify-content: center;
+        gap: 12px;
+        margin: 32px 0;
+      }
+      .hax-btn {
+        font-size: 18px;
+        padding: 10px 24px;
+        color: #ffffff;
+        background-color: var(--installer-accent);
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background-color 0.2s ease-in-out;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .hax-btn:hover,
+      .hax-btn:focus {
+        background-color: var(--installer-accent-hover);
+      }
+      .hax-btn.secondary {
+        background-color: var(--installer-surface);
+        color: var(--installer-text);
+        border: 2px solid var(--installer-border);
+      }
+      .hax-btn.secondary:hover,
+      .hax-btn.secondary:focus {
+        border-color: var(--installer-accent);
+      }
+      .credential-box {
+        background-color: var(--installer-surface);
+        border: 1px solid var(--installer-border);
+        border-radius: 8px;
+        padding: 16px;
+        margin: 16px 0;
+      }
+      .credential-box .credential-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 8px 0;
+      }
+      .credential-box .credential-row strong {
+        font-size: 20px;
+        font-family: monospace;
+        background: none;
+        padding: 0;
+        margin: 0;
+      }
+      .copy-btn {
+        font-size: 14px;
+        padding: 4px 12px;
+        background-color: var(--installer-bg);
+        color: var(--installer-text);
+        border: 1px solid var(--installer-border);
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      .copy-btn:hover { border-color: var(--installer-accent); }
+      .warning-box {
+        background-color: var(--installer-surface);
+        border-left: 4px solid var(--installer-warning);
+        border-radius: 4px;
+        padding: 12px 16px;
+        margin: 16px 0;
+        font-size: 16px;
+      }
+      .error-box {
+        background-color: var(--installer-surface);
+        border-left: 4px solid var(--installer-error);
+        border-radius: 4px;
+        padding: 12px 16px;
+        margin: 16px 0;
+        font-size: 16px;
+      }
+      .error-box ul { margin: 8px 0 0; padding-left: 20px; }
+      .error-box li { font-size: 16px; }
       .status-panel {
         margin-top: 32px;
-        background-color: #f6f6f6;
-        border: 2px solid #d8d8d8;
+        background-color: var(--installer-surface);
+        border: 1px solid var(--installer-border);
         border-radius: 8px;
         padding: 12px;
       }
-      .status-panel h2 {
-        margin: 0 0 8px;
-        font-size: 24px;
-      }
-      .status-summary {
-        margin: 0 0 12px;
-        font-size: 16px;
-      }
+      .status-panel h2 { margin: 0 0 8px; font-size: 24px; }
+      .status-summary { margin: 0 0 12px; font-size: 16px; }
       .status-table {
         width: 100%;
         border-collapse: collapse;
@@ -232,20 +617,35 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
       .status-table td {
         padding: 8px;
         text-align: left;
-        border-bottom: 1px solid #cfcfcf;
+        border-bottom: 1px solid var(--installer-border);
         vertical-align: top;
       }
       .status-table tbody tr.status-tone-ok td:first-child {
-        border-left: 4px solid #2e7d32;
+        border-left: 4px solid var(--installer-success);
       }
       .status-table tbody tr.status-tone-warning td:first-child {
-        border-left: 4px solid #f9a825;
+        border-left: 4px solid var(--installer-warning);
       }
       .status-table tbody tr.status-tone-error td:first-child {
-        border-left: 4px solid #c62828;
+        border-left: 4px solid var(--installer-error);
       }
       .status-table tbody tr.status-tone-info td:first-child {
-        border-left: 4px solid #1565c0;
+        border-left: 4px solid var(--installer-info);
+      }
+      code {
+        background-color: var(--installer-surface);
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 14px;
+      }
+      /* World traveler globe icon — the HAX icon, reflecting the
+         worldwide / localization reach of the installer. */
+      .world-traveler-icon {
+        display: block;
+        margin: 0 auto 8px;
+        color: var(--installer-accent);
+        --simple-icon-width: var(--ddd-icon-size-8, 64px);
+        --simple-icon-height: var(--ddd-icon-size-8, 64px);
       }
     </style>
   </head>
@@ -254,188 +654,161 @@ if (is_dir('_sites') && is_dir('_config') && is_dir('_published') && is_dir('_ar
     <div class="wrapper">
       <div class="card">
 <?php
-  include_once 'system/backend/php/lib/Git.php';
-  // add git library
-  $generateSecureSecret = function () {
-    $parts = array();
-    for ($i = 0; $i < 4; $i++) {
-      $parts[] = bin2hex(random_bytes(16));
-    }
-    return implode('-', $parts);
-  };
-  if (!is_dir('_config')) {
-    // gotta config some place now don't we
-    if (!mkdir('_config')) {
-      $failed = true;
-    }
-    // place for the ssh key chain specific to haxcms if desired
-    mkdir('_config/.ssh');
-    // tmp directory for uploads and other file management
-    mkdir('_config/tmp');
-    mkdir('_config/cache');
-    mkdir('_config/settings');
-    mkdir('_config/user');
-    mkdir('_config/user/files');
-    // node modules for local theme development if desired
-    mkdir('_config/node_modules');
-    // make config.json boilerplate
-    copy(
-      'system/boilerplate/systemsetup/config.json',
-      '_config/config.json'
-    );
-    // make a file to do custom theme development in
-    copy(
-      'system/boilerplate/systemsetup/my-custom-elements.js',
-      '_config/my-custom-elements.js'
-    );
-    // make a file for userData to reside
-    copy(
-      'system/boilerplate/systemsetup/userData.json',
-      '_config/userData.json'
-    );
-    // make a config.php boilerplate for larger overrides
-    copy('system/boilerplate/systemsetup/config.php', '_config/config.php');
-    // htaccess files
-    copy('system/boilerplate/systemsetup/.htaccess', '_config/.htaccess');
-    copy('system/boilerplate/systemsetup/.user-files-htaccess', '_config/user/files/.htaccess');
-    // set permissions
-    chmod("_config", 0755);
-    chmod("_config/tmp", 0755);
-    chmod("_config/config.json", 0644);
-    chmod("_config/userData.json", 0644);
-    // identifies this as a config directory for HAXcms since it is a generic name
-    file_put_contents(
-      '_config/.isHAXcmsConfig', ""
-    );
-    // set SALT
-    // Security (SEC-10): SALT.txt mixes into every HMAC/JWT signature; restrict
-    // to 0600 and write with LOCK_EX so co-located system users cannot read it.
-    file_put_contents(
-      '_config/SALT.txt',
-      $generateSecureSecret(),
-      LOCK_EX
-    );
-    @chmod('_config/SALT.txt', 0600);
+  // --- step indicators ---
+  $stepNum = 1;
+  if ($step === 'confirm') { $stepNum = 2; }
+  if ($step === 'install') { $stepNum = 3; }
+  print '<div class="step-indicator" aria-label="Installation progress">';
+  for ($i = 1; $i <= 3; $i++) {
+    $cls = 'step-dot';
+    if ($i < $stepNum) { $cls .= ' done'; }
+    if ($i === $stepNum) { $cls .= ' active'; }
+    print '<span class="' . $cls . '"></span>';
+  }
+  print '</div>';
+?>
 
-    // set things in config file from the norm
-    $configFile = file_get_contents('_config/config.php');
-    // private key
-    $configFile = str_replace(
-      'HAXTHEWEBPRIVATEKEY',
-      $generateSecureSecret(),
-      $configFile
-    );
-    // refresh private key
-    $configFile = str_replace(
-      'HAXTHEWEBREFRESHPRIVATEKEY',
-      $generateSecureSecret(),
-      $configFile
-    );
-    // user
-    if(isset($_POST['user'])){
-      $configFile = str_replace('jeff', filter_var($_POST['user'], FILTER_SANITIZE_FULL_SPECIAL_CHARS), $configFile);
-    }
-    else{
-      $configFile = str_replace('jeff', 'admin', $configFile);
-    }
-    // support POST for password in this setup phase
-    // this is typial of hosting environments that need
-    // to see the login details ahead of time in order
-    // to set things up correctly
-    if(isset($_POST['pass'])){
-      $pass = filter_var($_POST['pass'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-    }
-    else {
-      // pass
-      $alphabet =
-          'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789';
-      $pass = array(); //remember to declare $pass as an array
-      $alphaLength = strlen($alphabet) - 1; //put the length -1 in cache
-      for ($i = 0; $i < 12; $i++) {
-          $n = random_int(0, $alphaLength);
-          $pass[] = $alphabet[$n];
-      }
-      $pass = implode($pass);
-    }
-    // Security best practice: persist a password_hash (bcrypt/argon2) in
-    // config.php, never the plaintext. The plaintext $pass is still shown once
-    // on the install success screen below so the admin can capture it; only
-    // the hash is stored at rest and verified via password_verify at login.
-    $configFile = str_replace('jimmerson', password_hash($pass, PASSWORD_DEFAULT), $configFile);
-    // work on base path relative to where this was just launched from
-    // super sneaky and locks it to where it's currently installed but required
-    // or we don't know where to look for anything
-    $basePath = str_replace('install.php', '', $_SERVER['SCRIPT_NAME']); 
-    $configFile = str_replace("->basePath = '/'", "->basePath = '$basePath'", $configFile);
-    // Security (SEC-10): config.php holds the JWT private key + password hash;
-    // restrict to 0600 and write with LOCK_EX so co-located users cannot read it.
-    file_put_contents('_config/config.php', $configFile, LOCK_EX);
-    @chmod('_config/config.php', 0600);
-    $git = new Git();
-    $git->create('_config');
-  }
-  if (!is_dir('_sites')) {
-    // make sites directory
-    mkdir('_sites');
-    chmod("_sites", 0755);
-    // attempt to set the user / group on sites
-    // these probaly won't work
-    @chown('_sites', get_current_user());
-    @chgrp('_sites', get_current_user());
-    $git = new Git();
-    $git->create('_sites');
-  }
-  if (!is_dir('_published')) {
-    // make published directory so you can have a copy of these files
-    mkdir('_published');
-    chmod("_published", 0755);
-    // attempt to set the user / group on sites
-    // these probaly won't work
-    @chown('_published', get_current_user());
-    @chgrp('_published', get_current_user());
-  }
-  if (!is_dir('_archived')) {
-    // make published directory so you can have a copy of these files
-    mkdir('_archived');
-    chmod("_archived", 0755);
-    // attempt to set the user / group on sites
-    // these probaly won't work
-    @chown('_archived', get_current_user());
-    @chgrp('_archived', get_current_user());
-  }
-}
-$installerStatusReport = HAXCMSSystemStatusService::buildInstallerStatusReport(__DIR__);
-if ($failed) { ?>
-        <hax-logo hide-hax>install-issue</hax-logo><div class="version">V<?php print $version;?></div>
-        <h1>HAXcms folder needs to be writeable</h1>
+<?php if ($directInstallTokenError !== '') { ?>
+        <hax-logo hide-hax>install-issue</hax-logo><div class="version">V<?php print haxcmsInstallerStatusEscape($version);?></div>
+        <h1>Install token validation failed</h1>
+        <div class="error-box">
+          <p><?php print haxcmsInstallerStatusEscape($directInstallTokenError); ?></p>
+          <p>If you are a hosting provider integrating with HAXcms, ensure you pre-drop a <code>_installtoken.txt</code> file in the webroot before POSTing credentials, and include the matching value as <code>install_token</code> in your POST.</p>
+        </div>
+        <?php haxcmsInstallerStatusRender($installerStatusReport); ?>
+<?php } else if ($failed) { ?>
+        <hax-logo hide-hax>install-issue</hax-logo><div class="version">V<?php print haxcmsInstallerStatusEscape($version);?></div>
+        <h1>HAXcms installation encountered errors</h1>
+        <?php if (count($failedMessages) > 0) { ?>
+        <div class="error-box">
+          <ul>
+            <?php foreach ($failedMessages as $msg) { ?>
+            <li><?php print haxcmsInstallerStatusEscape($msg); ?></li>
+            <?php } ?>
+          </ul>
+        </div>
+        <?php } ?>
         <p>
           You can modify permissions in order to achieve this
-          <pre>chmod 0755 <?php print __DIR__; ?></pre>
-          Or the prefered method is to run:
-          <pre><?php print "bash " . __DIR__ . "/scripts/haxtheweb.sh"; ?></pre>
-          A complete installation guide can be read on 
-          <a href="https://haxtheweb.org/installation" target="_blank"  rel="noopener noreferrer">
-          <button raised><iron-icon icon="icons:build"></iron-icon> HAXTheWeb</simple-button></a>.
+          <pre>chmod 0755 <?php print haxcmsInstallerStatusEscape(__DIR__); ?></pre>
+          Or the preferred method is to run:
+          <pre><?php print haxcmsInstallerStatusEscape("bash " . __DIR__ . "/scripts/haxtheweb.sh"); ?></pre>
+          A complete installation guide can be read on
+          <a href="https://haxtheweb.org/installation" target="_blank" rel="noopener noreferrer">
+            <simple-icon-button-lite icon="icons:public" label="HAXTheWeb"></simple-icon-button-lite>
+          </a>
         </p>
         <?php haxcmsInstallerStatusRender($installerStatusReport); ?>
-<?php } else { ?>
-        <hax-logo hide-hax>HAX</hax-logo><div class="version">V<?php print $version;?></div>
+<?php } else if ($step === 'install') { ?>
+        <hax-logo hide-hax>HAX</hax-logo><div class="version">V<?php print haxcmsInstallerStatusEscape($version);?></div>
+        <simple-icon-lite icon="icons:public" class="world-traveler-icon" aria-hidden="true"></simple-icon-lite>
         <h1>Install successful</h1>
-        <p>If you don' see any errors then that means HAXcms has been successfully installed!
+        <p>If you don't see any errors then that means HAXcms has been successfully installed!
         Configuration settings were saved to <strong>_config/config.php</strong></p>
-        <ul>
-          <li>Username: <strong>admin</strong></li>
-          <li>Password: <strong><?php print $pass; ?></strong></li>
-        </ul>
-        <a href="index.php" tabindex="-1"><button class="hax-btn">Access HAXcms</button></a>
-        <p>Ideas to share or experiencing issues? <a href="http://github.com/elmsln/issues/issues" target="_blank" rel="noopener noreferrer" tabindex="-1">
-        <button class="hax-btn smaller">Join our community</button></a></p>
+        <?php if ($passwordWasGenerated || $pass !== '') { ?>
+        <div class="credential-box">
+          <div class="credential-row">
+            <span>Username:</span>
+            <strong id="install-username"><?php print haxcmsInstallerStatusEscape($resolvedUsername); ?></strong>
+            <button class="copy-btn" onclick="haxcmsInstallerCopy('install-username')">Copy</button>
+          </div>
+          <div class="credential-row">
+            <span>Password:</span>
+            <strong id="install-password"><?php print haxcmsInstallerStatusEscape($pass); ?></strong>
+            <button class="copy-btn" onclick="haxcmsInstallerCopy('install-password')">Copy</button>
+          </div>
+        </div>
+        <div class="warning-box">
+          <strong>Important:</strong> These credentials will not be shown again. Please copy them now.
+          For security, change your password after your first login.
+        </div>
+        <?php } else { ?>
+        <div class="warning-box">
+          <strong>Configuration was already present.</strong> Your existing admin credentials are unchanged.
+          If you need to reset them, edit <code>_config/config.php</code> directly.
+        </div>
+        <?php } ?>
+        <div class="btn-row">
+          <a href="index.php" tabindex="-1"><button class="hax-btn">Access HAXcms</button></a>
+          <a href="http://github.com/haxtheweb/issues/issues" target="_blank" rel="noopener noreferrer" tabindex="-1">
+            <button class="hax-btn secondary">Join our community</button></a>
+        </div>
         <?php haxcmsInstallerStatusRender($installerStatusReport); ?>
+<?php } else if ($step === 'confirm') { ?>
+        <hax-logo hide-hax>HAX</hax-logo><div class="version">V<?php print haxcmsInstallerStatusEscape($version);?></div>
+        <h1>Configure your installation</h1>
+        <p>Review the status checks below, then customize your admin username and default language.</p>
+        <?php haxcmsInstallerStatusRender($installerStatusReport); ?>
+        <?php if ($statusHasErrors) { ?>
+        <div class="error-box">
+          <strong>Some precondition checks failed.</strong> You can still attempt installation, but errors above may cause problems. Consider resolving them first.
+        </div>
+        <?php } ?>
+        <form method="POST" class="install-form">
+          <input type="hidden" name="step" value="install">
+          <label for="username">Admin username</label>
+          <input type="text" id="username" name="username" value="admin" autocomplete="username" required>
+          <p class="help-text">A secure password will be auto-generated and shown on the next screen.</p>
+          <label for="language">Default language</label>
+          <select id="language" name="language">
+            <?php
+            foreach (HAXCMSLocalizationSettingsService::$SUPPORTED_LANGUAGES as $code => $label) {
+              $sel = ($code === $selectedLanguage) ? ' selected' : '';
+              print '<option value="' . haxcmsInstallerStatusEscape($code) . '"' . $sel . '>' . haxcmsInstallerStatusEscape($label) . '</option>';
+            }
+            ?>
+          </select>
+          <p class="help-text">New sites will default to this language. You can change it later in Configuration settings.</p>
+          <div class="btn-row">
+            <button type="submit" class="hax-btn">Install HAXcms</button>
+            <a href="install.php"><button type="button" class="hax-btn secondary">Back</button></a>
+          </div>
+        </form>
+<?php } else { /* step === 'status' */ ?>
+        <hax-logo hide-hax>HAX</hax-logo><div class="version">V<?php print haxcmsInstallerStatusEscape($version);?></div>
+        <simple-icon-lite icon="icons:public" class="world-traveler-icon" aria-hidden="true"></simple-icon-lite>
+        <h1>Welcome to HAXcms</h1>
+        <p>Let's get your HAXcms instance set up. First, we'll check your server environment to make sure everything is ready. HAXcms speaks your language — choose a default language for new sites in the next step.</p>
+        <?php haxcmsInstallerStatusRender($installerStatusReport); ?>
+        <?php if ($statusHasErrors) { ?>
+        <div class="warning-box">
+          <strong>Some precondition checks reported errors.</strong> You can still proceed, but you may want to resolve the issues above first. Use the preferred CLI method below if directory permissions are the issue:
+          <pre><?php print haxcmsInstallerStatusEscape("bash " . __DIR__ . "/scripts/haxtheweb.sh"); ?></pre>
+        </div>
+        <?php } ?>
+        <div class="btn-row">
+          <form method="POST">
+            <input type="hidden" name="step" value="confirm">
+            <button type="submit" class="hax-btn">Continue</button>
+          </form>
+        </div>
 <?php } ?>
-</div>
+      </div>
     </div>
     <script type="module">
       import "./build/es6/dist/build-install.js";
+    </script>
+    <script>
+      function haxcmsInstallerCopy(elementId) {
+        var el = document.getElementById(elementId);
+        if (!el) return;
+        var text = el.textContent;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(function() {
+            var btn = el.nextElementSibling;
+            if (btn) { btn.textContent = 'Copied!'; setTimeout(function() { btn.textContent = 'Copy'; }, 2000); }
+          });
+        } else {
+          var range = document.createRange();
+          range.selectNode(el);
+          globalThis.getSelection().removeAllRanges();
+          globalThis.getSelection().addRange(range);
+          document.execCommand('copy');
+          globalThis.getSelection().removeAllRanges();
+          var btn = el.nextElementSibling;
+          if (btn) { btn.textContent = 'Copied!'; setTimeout(function() { btn.textContent = 'Copy'; }, 2000); }
+        }
+      }
     </script>
   </body>
 </html>

--- a/system/backend/php/lib/HAXCMS.php
+++ b/system/backend/php/lib/HAXCMS.php
@@ -243,6 +243,14 @@ class HAXCMS
                 if (!isset($this->config->security->loginRateLimit)) {
                     $this->config->security->loginRateLimit = new stdClass();
                 }
+                // localization / system-wide defaults (default language seeded
+                // at install time and editable via the Configuration admin panel)
+                if (!isset($this->config->localization)) {
+                    $this->config->localization = new stdClass();
+                }
+                if (!isset($this->config->localization->defaultLanguage)) {
+                    $this->config->localization->defaultLanguage = 'en-US';
+                }
                 // load in core theme data
                 $themeData = json_decode(
                     file_get_contents(

--- a/system/backend/php/lib/LocalizationSettingsService.php
+++ b/system/backend/php/lib/LocalizationSettingsService.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Localization / system configuration settings service.
+ *
+ * Stores the system-wide default language (and future localization defaults)
+ * as a `localization` block directly on _config/config.json so that it is
+ * loaded at boot by HAXCMS::boot() (alongside mcp / security blocks) and is
+ * the single source of truth shared by the installer wizard, createSite, and
+ * the admin "Configuration" panel.
+ *
+ * This mirrors HAXCMSMediaSettingsService in shape (normalize* / read* /
+ * write* / hasSupported* / isValid*) so the matching get/save operation traits
+ * and NodeJS parity file follow the same proven pattern, while intentionally
+ * persisting to config.json rather than a separate _config/settings file,
+ * because the value must be readable before _config/settings is scanned and
+ * must be writable by install.php during initial bootstrap.
+ */
+class HAXCMSLocalizationSettingsService
+{
+  const DEFAULT_LANGUAGE = 'en-US';
+
+  // Curated set of common BCP-47 language tags. The per-site language field
+  // in SEO settings remains a free-text field (ISO 639-1), so this list is a
+  // convenience default set for the installer + Configuration panel only; it
+  // does not constrain what a site may be set to directly.
+  public static $SUPPORTED_LANGUAGES = array(
+    'en-US' => 'English (United States)',
+    'en-GB' => 'English (United Kingdom)',
+    'es-ES' => 'Spanish (Spain)',
+    'es-MX' => 'Spanish (Mexico)',
+    'fr-FR' => 'French (France)',
+    'de-DE' => 'German (Germany)',
+    'it-IT' => 'Italian (Italy)',
+    'pt-BR' => 'Portuguese (Brazil)',
+    'pt-PT' => 'Portuguese (Portugal)',
+    'nl-NL' => 'Dutch (Netherlands)',
+    'pl-PL' => 'Polish (Poland)',
+    'ru-RU' => 'Russian (Russia)',
+    'uk-UA' => 'Ukrainian (Ukraine)',
+    'ja-JP' => 'Japanese (Japan)',
+    'ko-KR' => 'Korean (Korea)',
+    'zh-CN' => 'Chinese (Simplified)',
+    'zh-TW' => 'Chinese (Traditional)',
+    'ar-SA' => 'Arabic (Saudi Arabia)',
+    'hi-IN' => 'Hindi (India)',
+    'tr-TR' => 'Turkish (Turkey)',
+    'sv-SE' => 'Swedish (Sweden)',
+    'da-DK' => 'Danish (Denmark)',
+    'fi-FI' => 'Finnish (Finland)',
+    'nb-NO' => 'Norwegian (Norway)',
+    'cs-CZ' => 'Czech (Czech Republic)',
+    'el-GR' => 'Greek (Greece)',
+    'he-IL' => 'Hebrew (Israel)',
+    'th-TH' => 'Thai (Thailand)',
+    'vi-VN' => 'Vietnamese (Vietnam)',
+    'id-ID' => 'Indonesian (Indonesia)',
+    'ro-RO' => 'Romanian (Romania)',
+    'hu-HU' => 'Hungarian (Hungary)',
+    'ca-ES' => 'Catalan (Spain)',
+  );
+
+  /**
+   * Resolve the config.json path the localization block lives on.
+   */
+  public static function getLocalizationSettingsFilePath($haxcms)
+  {
+    $defaultConfigDirectory = rtrim(getcwd(), '/') . '/_config';
+    $configDirectory = $defaultConfigDirectory;
+    if (
+      is_object($haxcms) &&
+      isset($haxcms->configDirectory) &&
+      is_string($haxcms->configDirectory) &&
+      trim($haxcms->configDirectory) !== ''
+    ) {
+      $configDirectory = $haxcms->configDirectory;
+    }
+    return rtrim($configDirectory, '/') . '/config.json';
+  }
+
+  /**
+   * Validate / normalize a single language code value. Returns the code if it
+   * is a non-empty string matching ^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$ (BCP-47
+   * shaped), else null. We intentionally do NOT restrict to the curated
+   * SUPPORTED_LANGUAGES list so that sites / hosts may use any valid tag; the
+   * curated list is only a UI convenience.
+   */
+  public static function normalizeDefaultLanguageValue($value)
+  {
+    if (is_null($value) || $value === '') {
+      return null;
+    }
+    $value = (string) $value;
+    // basic BCP-47-ish shape: 2-3 letter primary, optional 2-4 letter region
+    if (preg_match('/^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$/', $value) !== 1) {
+      return null;
+    }
+    // normalize the primary tag lower-case, region upper-case (en-US form)
+    $parts = explode('-', $value);
+    $parts[0] = strtolower($parts[0]);
+    if (isset($parts[1])) {
+      $parts[1] = strtoupper($parts[1]);
+    }
+    return implode('-', $parts);
+  }
+
+  public static function normalizeLocalizationSettings($input = array())
+  {
+    $source = array();
+    if (is_object($input)) {
+      $source = (array) $input;
+    }
+    else if (is_array($input)) {
+      $source = $input;
+    }
+    return array(
+      'defaultLanguage' => self::normalizeDefaultLanguageValue(
+        array_key_exists('defaultLanguage', $source) ? $source['defaultLanguage'] : null
+      ),
+    );
+  }
+
+  public static function hasSupportedLocalizationSettingsPayload($input = array())
+  {
+    $source = array();
+    if (is_object($input)) {
+      $source = (array) $input;
+    }
+    else if (is_array($input)) {
+      $source = $input;
+    }
+    return array_key_exists('defaultLanguage', $source);
+  }
+
+  public static function isValidDefaultLanguagePayloadValue($value)
+  {
+    if (is_null($value) || $value === '') {
+      return true;
+    }
+    return !is_null(self::normalizeDefaultLanguageValue($value));
+  }
+
+  /**
+   * Read the localization block out of _config/config.json (normalized).
+   * Returns array('defaultLanguage' => <code|null>).
+   */
+  public static function readLocalizationSettings($haxcms)
+  {
+    $filePath = self::getLocalizationSettingsFilePath($haxcms);
+    $existing = array();
+    if (file_exists($filePath) && is_file($filePath)) {
+      $raw = @file_get_contents($filePath);
+      if (is_string($raw) && trim($raw) !== '') {
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded) && isset($decoded['localization']) && is_array($decoded['localization'])) {
+          $existing = $decoded['localization'];
+        }
+      }
+    }
+    return self::normalizeLocalizationSettings($existing);
+  }
+
+  /**
+   * Write the localization block back into _config/config.json, preserving
+   * all other top-level config keys. Returns the normalized localization
+   * block that was persisted.
+   */
+  public static function writeLocalizationSettings($haxcms, $settings = array())
+  {
+    $filePath = self::getLocalizationSettingsFilePath($haxcms);
+    if (!file_exists($filePath) || !is_file($filePath)) {
+      throw new Exception('Unable to locate config.json for localization settings');
+    }
+    $source = array();
+    if (is_object($settings)) {
+      $source = (array) $settings;
+    }
+    else if (is_array($settings)) {
+      $source = $settings;
+    }
+    // load the full config so we preserve sibling keys
+    $raw = @file_get_contents($filePath);
+    $config = json_decode($raw, true);
+    if (!is_array($config)) {
+      throw new Exception('Unable to parse config.json for localization settings');
+    }
+    if (!isset($config['localization']) || !is_array($config['localization'])) {
+      $config['localization'] = array();
+    }
+    if (array_key_exists('defaultLanguage', $source)) {
+      $config['localization']['defaultLanguage'] = self::normalizeDefaultLanguageValue(
+        $source['defaultLanguage']
+      );
+    }
+    $json = json_encode($config, JSON_PRETTY_PRINT);
+    if (!is_string($json)) {
+      throw new Exception('Unable to encode localization settings');
+    }
+    $written = @file_put_contents($filePath, $json . PHP_EOL, LOCK_EX);
+    if ($written === false) {
+      throw new Exception('Unable to write localization settings');
+    }
+    return self::normalizeLocalizationSettings($config['localization']);
+  }
+}

--- a/system/backend/php/lib/operations/OperationsMethodMap.php
+++ b/system/backend/php/lib/operations/OperationsMethodMap.php
@@ -15,6 +15,8 @@ class OperationsMethodMap {
       'saveApiKeys' => dirname(__FILE__) . '/saveApiKeys.php',
       'getMediaSettings' => dirname(__FILE__) . '/getMediaSettings.php',
       'saveMediaSettings' => dirname(__FILE__) . '/saveMediaSettings.php',
+      'getLocalizationSettings' => dirname(__FILE__) . '/getLocalizationSettings.php',
+      'saveLocalizationSettings' => dirname(__FILE__) . '/saveLocalizationSettings.php',
       'saveOutline' => dirname(__FILE__) . '/saveOutline.php',
       'createNode' => dirname(__FILE__) . '/createNode.php',
       'saveNode' => dirname(__FILE__) . '/saveNode.php',

--- a/system/backend/php/lib/operations/OperationsMethods.php
+++ b/system/backend/php/lib/operations/OperationsMethods.php
@@ -13,6 +13,8 @@ trait OperationsMethods {
   use OperationsRouteSaveApiKeys;
   use OperationsRouteGetMediaSettings;
   use OperationsRouteSaveMediaSettings;
+  use OperationsRouteGetLocalizationSettings;
+  use OperationsRouteSaveLocalizationSettings;
   use OperationsRouteSaveOutline;
   use OperationsRouteCreateNode;
   use OperationsRouteSaveNode;

--- a/system/backend/php/lib/operations/createSite.php
+++ b/system/backend/php/lib/operations/createSite.php
@@ -370,7 +370,20 @@ trait OperationsRouteCreateSite {
         $schema->metadata->site->settings = new stdClass();
       }
       if (!isset($schema->metadata->site->settings->lang) || $schema->metadata->site->settings->lang === '') {
-        $schema->metadata->site->settings->lang = 'en-US';
+        // fall back to the system-wide default language (set at install time
+        // and editable via the Configuration admin panel) when present, else
+        // the documented en-US default.
+        $systemDefaultLang = 'en-US';
+        if (
+          isset($GLOBALS['HAXCMS']->config->localization) &&
+          is_object($GLOBALS['HAXCMS']->config->localization) &&
+          isset($GLOBALS['HAXCMS']->config->localization->defaultLanguage) &&
+          is_string($GLOBALS['HAXCMS']->config->localization->defaultLanguage) &&
+          $GLOBALS['HAXCMS']->config->localization->defaultLanguage !== ''
+        ) {
+          $systemDefaultLang = $GLOBALS['HAXCMS']->config->localization->defaultLanguage;
+        }
+        $schema->metadata->site->settings->lang = $systemDefaultLang;
       }
       if (!isset($schema->metadata->site->settings->publishPagesOn)) {
         $schema->metadata->site->settings->publishPagesOn = true;

--- a/system/backend/php/lib/operations/getLocalizationSettings.php
+++ b/system/backend/php/lib/operations/getLocalizationSettings.php
@@ -1,0 +1,36 @@
+<?php
+include_once dirname(__FILE__) . '/../LocalizationSettingsService.php';
+trait OperationsRouteGetLocalizationSettings {
+  public function getLocalizationSettings() {
+    if (!isset($this->params['user_token']) || !$GLOBALS['HAXCMS']->validateRequestToken($this->params['user_token'], $GLOBALS['HAXCMS']->getActiveUserName())) {
+      return array(
+        '__failed' => array(
+          'status' => 403,
+          'message' => 'invalid request token',
+        ),
+      );
+    }
+    try {
+      $localizationSettings = HAXCMSLocalizationSettingsService::readLocalizationSettings($GLOBALS['HAXCMS']);
+      // Apply effective defaults so null/missing fields are reported with the
+      // documented default (parity with Node getEffectiveLocalizationSettings).
+      $effective = array(
+        'defaultLanguage' => (isset($localizationSettings['defaultLanguage']) && !is_null($localizationSettings['defaultLanguage']))
+          ? $localizationSettings['defaultLanguage']
+          : HAXCMSLocalizationSettingsService::DEFAULT_LANGUAGE,
+      );
+      return array(
+        'status' => 200,
+        'data' => $effective,
+      );
+    }
+    catch (Exception $e) {
+      return array(
+        '__failed' => array(
+          'status' => 500,
+          'message' => 'Unable to load localization settings',
+        ),
+      );
+    }
+  }
+}

--- a/system/backend/php/lib/operations/saveLocalizationSettings.php
+++ b/system/backend/php/lib/operations/saveLocalizationSettings.php
@@ -1,0 +1,84 @@
+<?php
+include_once dirname(__FILE__) . '/../LocalizationSettingsService.php';
+trait OperationsRouteSaveLocalizationSettings {
+  private function resolveLocalizationSettingsPayload() {
+    $source = null;
+    if (isset($this->params['localizationSettings']) && (is_array($this->params['localizationSettings']) || is_object($this->params['localizationSettings']))) {
+      $source = $this->params['localizationSettings'];
+    }
+    else if (isset($this->rawParams['localizationSettings']) && (is_array($this->rawParams['localizationSettings']) || is_object($this->rawParams['localizationSettings']))) {
+      $source = $this->rawParams['localizationSettings'];
+    }
+    else if (is_array($this->params)) {
+      $source = $this->params;
+    }
+    if (is_object($source)) {
+      return (array) $source;
+    }
+    if (is_array($source)) {
+      return $source;
+    }
+    return array();
+  }
+
+  private function localizationPayloadHasNonEmptyValue($payload, $key) {
+    if (!is_array($payload) || !array_key_exists($key, $payload)) {
+      return false;
+    }
+    $value = $payload[$key];
+    return !is_null($value) && $value !== '';
+  }
+
+  public function saveLocalizationSettings() {
+    if (!isset($this->params['user_token']) || !$GLOBALS['HAXCMS']->validateRequestToken($this->params['user_token'], $GLOBALS['HAXCMS']->getActiveUserName())) {
+      return array(
+        '__failed' => array(
+          'status' => 403,
+          'message' => 'invalid request token',
+        ),
+      );
+    }
+    $payload = $this->resolveLocalizationSettingsPayload();
+    if (!HAXCMSLocalizationSettingsService::hasSupportedLocalizationSettingsPayload($payload)) {
+      return array(
+        '__failed' => array(
+          'status' => 400,
+          'message' => 'Missing localization settings payload',
+        ),
+      );
+    }
+    if ($this->localizationPayloadHasNonEmptyValue($payload, 'defaultLanguage')) {
+      if (!HAXCMSLocalizationSettingsService::isValidDefaultLanguagePayloadValue($payload['defaultLanguage'])) {
+        return array(
+          '__failed' => array(
+            'status' => 400,
+            'message' => 'Invalid defaultLanguage value',
+          ),
+        );
+      }
+    }
+    try {
+      $localizationSettings = HAXCMSLocalizationSettingsService::writeLocalizationSettings($GLOBALS['HAXCMS'], $payload);
+      // keep the in-memory config in sync so createSite and other runtime
+      // consumers see the new default without a reload
+      if (isset($GLOBALS['HAXCMS']->config)) {
+        if (!isset($GLOBALS['HAXCMS']->config->localization)) {
+          $GLOBALS['HAXCMS']->config->localization = new stdClass();
+        }
+        $GLOBALS['HAXCMS']->config->localization->defaultLanguage = $localizationSettings['defaultLanguage'];
+      }
+      return array(
+        'status' => 200,
+        'data' => $localizationSettings,
+      );
+    }
+    catch (Exception $e) {
+      return array(
+        '__failed' => array(
+          'status' => 500,
+          'message' => 'Unable to save localization settings',
+        ),
+      );
+    }
+  }
+}

--- a/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
+++ b/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
@@ -318,7 +318,7 @@ class SystemApiSecurity
             'v1/schemas' => array('GET', 'POST'),
             'v1/configuration/api-keys' => array('GET'),
             'v1/configuration/media' => array('GET'),
-            'v1/configuration/localization' => array('GET'),
+            'v1/configuration/localization' => array('GET', 'POST'),
             'v1/session/user' => array('GET', 'POST'),
         );
     }

--- a/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
+++ b/system/backend/php/lib/systemRoutes/SystemApiSecurity.php
@@ -318,6 +318,7 @@ class SystemApiSecurity
             'v1/schemas' => array('GET', 'POST'),
             'v1/configuration/api-keys' => array('GET'),
             'v1/configuration/media' => array('GET'),
+            'v1/configuration/localization' => array('GET'),
             'v1/session/user' => array('GET', 'POST'),
         );
     }

--- a/system/backend/php/lib/systemRoutes/SystemRoutesMap.php
+++ b/system/backend/php/lib/systemRoutes/SystemRoutesMap.php
@@ -35,6 +35,7 @@ class SystemRoutesMap
             'v1/schemas',
             'v1/configuration/api-keys',
             'v1/configuration/media',
+            'v1/configuration/localization',
             'v1/configuration/schema-files/operations',
             'v1/blocks',
             'v1/skeletons',
@@ -42,6 +43,7 @@ class SystemRoutesMap
             'v1/themes',
         );
     }
+
     /**
      * Subset of getSystemV1AdminRoutes() whose NON-GET methods require the
      * superUser principal (the true system-admin-dashboard routes: skeleton,
@@ -71,6 +73,7 @@ class SystemRoutesMap
             'v1/schemas',
             'v1/configuration/api-keys',
             'v1/configuration/media',
+            'v1/configuration/localization',
             'v1/configuration/schema-files/operations',
             'v1/blocks',
             'v1/skeletons',
@@ -121,6 +124,7 @@ class SystemRoutesMap
                 'v1/integrations/app-store/providers/:provider/search' => dirname(__FILE__) . '/v1/integrations.php',
                 'v1/configuration/api-keys' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/configuration/media' => dirname(__FILE__) . '/v1/settings.php',
+                'v1/configuration/localization' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/blocks' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/skeletons' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/skeletons/:skeletonName' => dirname(__FILE__) . '/v1/settings.php',
@@ -146,6 +150,7 @@ class SystemRoutesMap
                 'v1/schemas' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/configuration/api-keys' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/configuration/media' => dirname(__FILE__) . '/v1/settings.php',
+                'v1/configuration/localization' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/configuration/schema-files/operations' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/blocks' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/skeletons' => dirname(__FILE__) . '/v1/settings.php',
@@ -179,6 +184,7 @@ class SystemRoutesMap
             'PATCH' => array(
                 'v1/configuration/api-keys' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/configuration/media' => dirname(__FILE__) . '/v1/settings.php',
+                'v1/configuration/localization' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/blocks' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/skeletons' => dirname(__FILE__) . '/v1/settings.php',
                 'v1/skeletons/:skeletonName' => dirname(__FILE__) . '/v1/settings.php',

--- a/system/backend/php/lib/systemRoutes/openapi/system-spec.yaml
+++ b/system/backend/php/lib/systemRoutes/openapi/system-spec.yaml
@@ -993,6 +993,89 @@ paths:
                 additionalProperties: true
         "403":
           $ref: "#/components/responses/Forbidden"
+  /system/api/v1/configuration/localization:
+    get:
+      tags:
+        - settings
+      operationId: getLocalizationSettings
+      summary: Return localization and system default configuration
+      security:
+        - bearerAuth: []
+          userTokenHeader: []
+      responses:
+        "200":
+          description: Localization settings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                  data:
+                    $ref: "#/components/schemas/LocalizationSettingsData"
+                additionalProperties: true
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - settings
+      operationId: getLocalizationSettingsPost
+      summary: Return localization and system default configuration (read alias of GET)
+      description: >
+        Read-only alias of GET /configuration/localization. POST is accepted
+        for callers that prefer POST over GET but does not write; use PATCH to
+        update localization settings. Single-user deployment assumption: the
+        NodeJS backend does not model an admin/superUser tier; these settings
+        are written by the single authenticated dashboard user.
+      security:
+        - bearerAuth: []
+          userTokenHeader: []
+      responses:
+        "200":
+          description: Localization settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiEnvelope"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - settings
+      operationId: saveLocalizationSettingsPatch
+      summary: Update localization and system default configuration
+      description: >
+        Write operation — updates the system-wide default language (and future
+        localization defaults). The persisted value seeds the default language
+        applied to newly created sites and is editable post-install via the
+        Configuration admin panel. Single-user deployment assumption: the
+        NodeJS backend does not model an admin/superUser tier; settings are
+        written by the single authenticated dashboard user.
+      security:
+        - bearerAuth: []
+          userTokenHeader: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocalizationSettings"
+      responses:
+        "200":
+          description: Localization settings update response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                  data:
+                    $ref: "#/components/schemas/LocalizationSettingsData"
+                additionalProperties: true
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /system/api/v1/configuration/schema-files/operations:
     post:
       tags:
@@ -2740,6 +2823,17 @@ components:
       type: object
       description: Media settings payload
       additionalProperties: true
+    LocalizationSettings:
+      type: object
+      description: >
+        Localization / system default settings payload. The `defaultLanguage`
+        value is a BCP-47 shaped language tag (e.g. en-US) applied as the
+        default language for newly created sites.
+      properties:
+        defaultLanguage:
+          type: string
+          description: BCP-47 language tag (e.g. en-US, es-ES).
+      additionalProperties: true
     EnabledCollectionSettings:
       type: object
       description: Enabled item map payload
@@ -3016,6 +3110,16 @@ components:
         maxUploadSizeMb:
           type: integer
         acceptedFormats:
+          type: string
+      additionalProperties: true
+    LocalizationSettingsData:
+      type: object
+      description: >
+        Localization settings returned by getLocalizationSettings and
+        saveLocalizationSettingsPatch. The front-end (haxcms-system-settings
+        Configuration panel) reads `data.defaultLanguage`.
+      properties:
+        defaultLanguage:
           type: string
       additionalProperties: true
     SchemaFileOperationData:

--- a/system/backend/php/lib/systemRoutes/v1/settings.php
+++ b/system/backend/php/lib/systemRoutes/v1/settings.php
@@ -25,8 +25,9 @@ if (!function_exists('haxcmsSystemSettingsRequiresUserTokenHeader')) {
         if ($route === 'v1/configuration/schema-files/operations') {
             return true;
         }
-        // Toggle PATCH writes (skeletons/themes/blocks + api-keys/media) enforce
-        // the header per the system-dashboard-write directive.
+        // Toggle PATCH writes (skeletons/themes/blocks + api-keys/media +
+        // localization) enforce the header per the system-dashboard-write
+        // directive.
         if (
             $normalizedMethod === 'PATCH' &&
             (
@@ -34,7 +35,8 @@ if (!function_exists('haxcmsSystemSettingsRequiresUserTokenHeader')) {
                 $route === 'v1/themes' ||
                 $route === 'v1/blocks' ||
                 $route === 'v1/configuration/api-keys' ||
-                $route === 'v1/configuration/media'
+                $route === 'v1/configuration/media' ||
+                $route === 'v1/configuration/localization'
             )
         ) {
             return true;
@@ -63,14 +65,15 @@ if (!function_exists('haxcmsSystemSettingsRequiresUserTokenHeader')) {
                 return true;
             }
         }
-        // GET-only reads: api-keys/media GET declare userTokenHeader, but the
-        // POST aliases (saveApiKeysPost / saveMediaSettingsPost) are bearer-only
-        // per the spec, so only GET feeds the client header. PATCH writes are
-        // already handled above.
+        // GET-only reads: api-keys/media/localization GET declare userTokenHeader,
+        // but the POST aliases (saveApiKeysPost / saveMediaSettingsPost) are
+        // bearer-only per the spec, so only GET feeds the client header. PATCH
+        // writes are already handled above.
         if ($normalizedMethod === 'GET') {
             $readRoutesGetOnly = array(
                 'v1/configuration/api-keys',
                 'v1/configuration/media',
+                'v1/configuration/localization',
             );
             if (in_array($route, $readRoutesGetOnly, true)) {
                 return true;
@@ -425,6 +428,18 @@ return function ($context) {
         else {
             $response = haxcmsSystemSettingsInvokeAsPost(
                 array($operations, 'saveMediaSettings')
+            );
+        }
+    }
+    else if ($route === 'v1/configuration/localization') {
+        if ($method === 'GET' || $method === 'POST') {
+            $response = haxcmsSystemSettingsInvokeAsPost(
+                array($operations, 'getLocalizationSettings')
+            );
+        }
+        else {
+            $response = haxcmsSystemSettingsInvokeAsPost(
+                array($operations, 'saveLocalizationSettings')
             );
         }
     }

--- a/system/backend/php/tests/Unit/OperationsSettingsTest.php
+++ b/system/backend/php/tests/Unit/OperationsSettingsTest.php
@@ -453,6 +453,97 @@ class OperationsSettingsTest extends TestCase
         $this->assertSame('jpg,jpeg,png,gif,webp,svg', $result['data']['acceptedFormats']);
     }
 
+    // ===== saveLocalizationSettings =====
+
+    public function testSaveLocalizationSettingsFailsWithInvalidUserToken(): void
+    {
+        $this->haxcms->validRequestToken = false;
+        $this->ops->params = array('user_token' => 'bad');
+        $result = $this->ops->saveLocalizationSettings();
+        $this->assertSame(403, $result['__failed']['status']);
+        $this->assertSame('invalid request token', $result['__failed']['message']);
+    }
+
+    public function testSaveLocalizationSettingsFailsWithMissingPayload(): void
+    {
+        $this->haxcms->validRequestToken = true;
+        $this->ops->params = array('user_token' => 'good');
+        $result = $this->ops->saveLocalizationSettings();
+        $this->assertSame(400, $result['__failed']['status']);
+        $this->assertSame('Missing localization settings payload', $result['__failed']['message']);
+    }
+
+    public function testSaveLocalizationSettingsFailsWithInvalidLanguage(): void
+    {
+        $this->haxcms->validRequestToken = true;
+        $this->ops->params = array(
+            'user_token' => 'good',
+            'localizationSettings' => array('defaultLanguage' => 'not-a-valid-tag!!'),
+        );
+        $result = $this->ops->saveLocalizationSettings();
+        $this->assertSame(400, $result['__failed']['status']);
+        $this->assertSame('Invalid defaultLanguage value', $result['__failed']['message']);
+    }
+
+    public function testSaveLocalizationSettingsPersistsToConfigJson(): void
+    {
+        $this->haxcms->validRequestToken = true;
+        // Seed config.json so writeLocalizationSettings can load+preserve it.
+        $configPath = $this->haxcms->configDirectory . '/config.json';
+        file_put_contents($configPath, json_encode(array(
+            'deploymentProfile' => 'self-hosted-multi-site',
+            'themes' => new stdClass(),
+        ), JSON_PRETTY_PRINT));
+        $this->ops->params = array(
+            'user_token' => 'good',
+            'localizationSettings' => array('defaultLanguage' => 'es-ES'),
+        );
+        $result = $this->ops->saveLocalizationSettings();
+        $this->assertSame(200, $result['status']);
+        $this->assertSame('es-ES', $result['data']['defaultLanguage']);
+        // Localization settings write to the localization block on config.json
+        // (NOT a separate settings file), so verify config.json was updated.
+        $this->assertFileExists($configPath);
+        $persisted = json_decode(file_get_contents($configPath), true);
+        $this->assertSame('es-ES', $persisted['localization']['defaultLanguage']);
+        // Sibling keys must be preserved.
+        $this->assertSame('self-hosted-multi-site', $persisted['deploymentProfile']);
+    }
+
+    // ===== getLocalizationSettings =====
+
+    public function testGetLocalizationSettingsFailsWithInvalidUserToken(): void
+    {
+        $this->haxcms->validRequestToken = false;
+        $this->ops->params = array('user_token' => 'bad');
+        $result = $this->ops->getLocalizationSettings();
+        $this->assertSame(403, $result['__failed']['status']);
+        $this->assertSame('invalid request token', $result['__failed']['message']);
+    }
+
+    public function testGetLocalizationSettingsReturnsEffectiveDefaultsWhenNoConfig(): void
+    {
+        $this->haxcms->validRequestToken = true;
+        $this->ops->params = array('user_token' => 'good');
+        $result = $this->ops->getLocalizationSettings();
+        $this->assertSame(200, $result['status']);
+        // Documented effective default (parity with Node getEffectiveLocalizationSettings).
+        $this->assertSame('en-US', $result['data']['defaultLanguage']);
+    }
+
+    public function testGetLocalizationSettingsReturnsPersistedValue(): void
+    {
+        $this->haxcms->validRequestToken = true;
+        $configPath = $this->haxcms->configDirectory . '/config.json';
+        file_put_contents($configPath, json_encode(array(
+            'localization' => array('defaultLanguage' => 'fr-FR'),
+        ), JSON_PRETTY_PRINT));
+        $this->ops->params = array('user_token' => 'good');
+        $result = $this->ops->getLocalizationSettings();
+        $this->assertSame(200, $result['status']);
+        $this->assertSame('fr-FR', $result['data']['defaultLanguage']);
+    }
+
     // ===== getSkeleton =====
 
     public function testGetSkeletonFailsWithInvalidUserToken(): void

--- a/tests/docker-precondition-test.sh
+++ b/tests/docker-precondition-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Integration test for the HAXcms installer precondition-test Docker image.
+#
+# Builds Dockerfile.precondition-test, starts it, fetches install.php's Step 1
+# status report, and asserts that the expected missing-precondition warnings
+# are present. Exits non-zero if any assertion fails.
+#
+# Usage: bash tests/docker-precondition-test.sh
+# Requires: docker, curl, grep
+#
+# This is the test housing requested in haxtheweb/issues#2974.
+
+set -u
+
+IMAGE_TAG="haxcms-precondition-test:local"
+CONTAINER_NAME="haxcms-precondition-test-run"
+HOST_PORT="${HAXCMS_PRECONDITION_TEST_PORT:-8085}"
+START_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+fail() {
+  echo "FAIL: $1" >&2
+  if [ -n "${CONTAINER_ID:-}" ]; then
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+  exit 1
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+echo "Building precondition-test image from $START_DIR/Dockerfile.precondition-test ..."
+docker build -f "$START_DIR/Dockerfile.precondition-test" -t "$IMAGE_TAG" "$START_DIR" >/dev/null 2>&1 || fail "docker build failed"
+
+echo "Starting container on port $HOST_PORT ..."
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+CONTAINER_ID=$(docker run -d --rm --name "$CONTAINER_NAME" -p "$HOST_PORT:80" "$IMAGE_TAG")
+[ -n "$CONTAINER_ID" ] || fail "docker run did not return a container id"
+
+# Wait for Apache to come up (poll the installer endpoint).
+echo "Waiting for Apache to respond ..."
+READY=0
+for i in $(seq 1 30); do
+  if curl --silent --fail --max-time 3 "http://localhost:$HOST_PORT/install.php" >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+[ "$READY" -eq 1 ] || fail "Apache did not become reachable on port $HOST_PORT"
+
+echo "Fetching installer Step 1 status report ..."
+BODY=$(curl --silent --max-time 10 "http://localhost:$HOST_PORT/install.php")
+[ -n "$BODY" ] || fail "Empty response from install.php"
+
+# Assertion 1: PHP curl extension reported as Missing (error tone).
+echo "$BODY" | grep -qi 'PHP curl extension' || fail "status table missing 'PHP curl extension' row"
+echo "$BODY" | grep -qi 'Missing' || fail "curl extension row did not report 'Missing'"
+# The error-tone row gets the status-tone-error class on its <tr>.
+echo "$BODY" | grep -q 'status-tone-error' || fail "no error-tone rows present in status report"
+pass "PHP curl extension reported as Missing (error)"
+
+# Assertion 2: Git availability reported as Not detected (warning tone).
+echo "$BODY" | grep -qi 'Git availability' || fail "status table missing 'Git availability' row"
+echo "$BODY" | grep -qi 'Not detected' || fail "git row did not report 'Not detected'"
+pass "Git availability reported as Not detected (warning)"
+
+# Assertion 3: directory writability check surfaces a Read-only error.
+echo "$BODY" | grep -qi 'Read-only' || fail "no 'Read-only' directory status present"
+pass "Directory writability reported as Read-only (error)"
+
+# Assertion 4: the stepped wizard Step 1 welcome UI is present.
+echo "$BODY" | grep -qi 'Welcome to HAXcms' || fail "Step 1 'Welcome to HAXcms' heading not present"
+pass "Stepped wizard Step 1 welcome UI present"
+
+# Assertion 5: the step indicator is rendered.
+echo "$BODY" | grep -q 'step-indicator' || fail "step indicator markup not present"
+pass "Step indicator rendered"
+
+# Assertion 6: the Continue button to Step 2 is present.
+echo "$BODY" | grep -qi 'Continue' || fail "Continue button to Step 2 not present"
+pass "Continue button to Step 2 present"
+
+echo ""
+echo "All precondition-test assertions passed."
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+exit 0


### PR DESCRIPTION
## Summary

Replaces the single-shot unauthenticated `install.php` with a Drupal/WordPress-style stepped wizard and adds a system-wide default-language setting, per haxtheweb/issues#2974.

### Installer wizard + security hardening (`install.php`)
- **Stepped wizard**: Step 1 status check (reuses `HAXCMSSystemStatusService`) → Step 2 confirm username + pick default language → Step 3 success screen with copy-to-clipboard credentials.
- **Secure hosting-provider bypass**: POST-supplied `user`/`pass` are now gated behind a one-time `_installtoken.txt` file (timing-safe `hash_equals`). Without the token file, POSTed credentials are ignored and an admin password is auto-generated — closing the unauthenticated credential race.
- **Hardening**: removed dead duplicate dir-existence check; guarded every `mkdir()`/`Git::create()` with failure reporting; fixed hardcoded `Username: admin` display bug; replaced malformed `<button raised>...</simple-button>` with `simple-icon-button-lite`; added password policy (10+ chars, letters + numbers); DDD-token-based dark-mode-safe CSS. HAX icon is now the "world traveler" globe (`icons:public`).

### Localization settings service
- New `HAXCMSLocalizationSettingsService` (mirrors `HAXCMSMediaSettingsService`) storing `localization.defaultLanguage` on `_config/config.json` — single source of truth shared by the installer, `createSite`, and the admin Configuration panel.
- `getLocalizationSettings`/`saveLocalizationSettings` operations (token-validated), registered in `OperationsMethodMap.php`, wired into the `v1/configuration/localization` route (GET/POST/PATCH), documented in the OpenAPI spec.
- `createSite.php` now seeds new sites from `config.localization.defaultLanguage` (fallback `en-US`) instead of hardcoding.

### Docker precondition-test harness
- `Dockerfile.precondition-test` — minimal image intentionally missing git/curl-ext with a read-only webroot.
- `tests/docker-precondition-test.sh` — integration test asserting the wizard's Step 1 surfaces the expected missing-precondition warnings.

## Parity
- NodeJS backend: see companion PR in `haxtheweb/haxcms-nodejs`.
- Admin UI Configuration panel: see companion PR in `haxtheweb/webcomponents`.
- Reclaim Hosting JPS: `btopro/haxcms-jps` manifest updated to write `_installtoken.txt` and POST `install_token` (PR to `reclaimhosting/haxcms-jps` to follow).

## Validation
- `php -l` passes on all 11 modified PHP files.
- PHPUnit: **1453 tests, 0 failures** (11 pre-existing skips; includes new localization settings tests).

Refs haxtheweb/issues#2974

Co-Authored-By: Warp <agent@warp.dev>